### PR TITLE
修正: index.htmlの不要削除部分

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -268,12 +268,4 @@
     <!-- JavaScriptをロード -->
     <script src="script.js"></script>
   </body>
-                // カードをページに追加
-                document.getElementById("container").appendChild(card);
-            })
-            .catch((error) => {
-                console.error("データ取得エラー:", error);
-            });
-    </script>
-</body>
 </html>


### PR DESCRIPTION
index.htmlファイルの記述部分、271〜278行目迄を削除をしました。

<img width="615" alt="スクリーンショット 2025-01-23 11 37 56" src="https://github.com/user-attachments/assets/5f635e94-1cee-4c64-bdcc-6dec6cb7ae05" />

これで、この部分は非表示となっています。

![20250123_削除部分](https://github.com/user-attachments/assets/3687013a-06f5-4564-a7b7-529c57480ed9)


